### PR TITLE
تم تغير رقم اصدار cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 # --[ WebUI version ] --------------------------------------------------------------
 


### PR DESCRIPTION
from
cmake_minimum_required(VERSION 3.15.0)
to
 cmake_minimum_required(VERSION 3.13.4)