### PR TITLE
Disable First Run Dialog

### DIFF
--- a/src/webui.c
+++ b/src/webui.c
@@ -1884,7 +1884,7 @@ bool _webui_browser_start_chrome(webui_window_t* win, const char* address) {
         return false;
     
     char arg[1024];
-    sprintf(arg, " --user-data-dir=\"%s\" --disable-gpu --disable-software-rasterizer --no-proxy-server --safe-mode --disable-extensions --disable-background-mode --disable-plugins --disable-plugins-discovery --disable-translate --bwsi --app=", win->core.profile_path);
+    sprintf(arg, " --user-data-dir=\"%s\" --no-first-run --disable-gpu --disable-software-rasterizer --no-proxy-server --safe-mode --disable-extensions --disable-background-mode --disable-plugins --disable-plugins-discovery --disable-translate --bwsi --app=", win->core.profile_path);
 
     char full[1024];
     sprintf(full, "%s%s%s", win->core.browser_path, arg, address);


### PR DESCRIPTION
This pr disables chrome's first-run dialog at new profile creation.
![chrome-welcome](https://user-images.githubusercontent.com/87281783/198565279-93f69a86-afe4-4019-800a-2e5cfea5bf77.png)
